### PR TITLE
Refactor auth logic for `returnTo` params

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -44,6 +44,7 @@ export default function Profile() {
 
         if ('error' in body) {
           router.replace('/(auth)/login?returnTo=/(tabs)/profile');
+          return;
         }
       }
       getUser().catch((error) => {

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,4 +1,4 @@
-import { router, useFocusEffect } from 'expo-router';
+import { useFocusEffect, useRouter } from 'expo-router';
 import React, { useCallback } from 'react';
 import { Alert, Pressable, StyleSheet, Text, View } from 'react-native';
 import type { LogoutResponseBodyGet } from '../(auth)/api/logout+api';
@@ -33,6 +33,8 @@ const styles = StyleSheet.create({
 });
 
 export default function Profile() {
+  const router = useRouter();
+
   useFocusEffect(
     useCallback(() => {
       async function getUser() {
@@ -41,14 +43,13 @@ export default function Profile() {
         const body: UserResponseBodyGet = await response.json();
 
         if ('error' in body) {
-          Alert.alert('Error', body.error, [{ text: 'OK' }]);
-          return router.push('/(auth)/login');
+          router.replace('/(auth)/login?returnTo=/(tabs)/profile');
         }
       }
       getUser().catch((error) => {
         console.error(error);
       });
-    }, []),
+    }, [router]),
   );
 
   return (

--- a/app/guests/[guestId].tsx
+++ b/app/guests/[guestId].tsx
@@ -123,35 +123,30 @@ export default function GuestPage() {
 
   useFocusEffect(
     useCallback(() => {
-      async function getUser() {
-        const response = await fetch('/api/user');
-
-        const body: UserResponseBodyGet = await response.json();
-
-        if ('error' in body) {
-          router.replace(`/(auth)/login?returnTo=/(tabs)/guests`);
-        }
-      }
-      getUser().catch((error) => {
-        console.error(error);
-      });
-
-      async function loadGuest() {
+      async function getUserAndLoadGuest() {
         if (typeof guestId !== 'string') {
           return;
         }
+        const [userResponse, guestResponse]: [
+          UserResponseBodyGet,
+          GuestResponseBodyGet,
+        ] = await Promise.all([
+          fetch('/api/user').then((response) => response.json()),
+          fetch(`/api/guests/${guestId}`).then((response) => response.json()),
+        ]);
 
-        const response = await fetch(`/api/guests/${guestId}`);
-        const responseBody: GuestResponseBodyGet = await response.json();
+        if ('error' in userResponse) {
+          router.replace(`/(auth)/login?returnTo=/guests/${guestId}`);
+        }
 
-        if ('guest' in responseBody) {
-          setFirstName(responseBody.guest.firstName);
-          setLastName(responseBody.guest.lastName);
-          setAttending(responseBody.guest.attending);
+        if ('guest' in guestResponse) {
+          setFirstName(guestResponse.guest.firstName);
+          setLastName(guestResponse.guest.lastName);
+          setAttending(guestResponse.guest.attending);
         }
       }
 
-      loadGuest().catch((error) => {
+      getUserAndLoadGuest().catch((error) => {
         console.error(error);
       });
     }, [guestId, router]),

--- a/app/guests/[guestId].tsx
+++ b/app/guests/[guestId].tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Image } from 'expo-image';
-import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
+import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useState } from 'react';
 import {
   Pressable,
@@ -13,6 +13,7 @@ import {
 import placeholder from '../../assets/candidate-default.avif';
 import { colors } from '../../constants/colors';
 import type { GuestResponseBodyGet } from '../api/guests/[guestId]+api';
+import type { UserResponseBodyGet } from '../api/user+api';
 
 const styles = StyleSheet.create({
   container: {
@@ -115,11 +116,26 @@ export default function GuestPage() {
   const [attending, setAttending] = useState(false);
   const [focusedInput, setFocusedInput] = useState<string | undefined>();
 
+  const router = useRouter();
+
   // Dynamic import of images
   // const imageContext = require.context('../../assets', false, /\.(avif)$/);
 
   useFocusEffect(
     useCallback(() => {
+      async function getUser() {
+        const response = await fetch('/api/user');
+
+        const body: UserResponseBodyGet = await response.json();
+
+        if ('error' in body) {
+          router.replace(`/(auth)/login?returnTo=/(tabs)/guests`);
+        }
+      }
+      getUser().catch((error) => {
+        console.error(error);
+      });
+
       async function loadGuest() {
         if (typeof guestId !== 'string') {
           return;
@@ -138,7 +154,7 @@ export default function GuestPage() {
       loadGuest().catch((error) => {
         console.error(error);
       });
-    }, [guestId]),
+    }, [guestId, router]),
   );
 
   if (typeof guestId !== 'string') {


### PR DESCRIPTION
This PR updates the profile screen and single guest screen to check for the user information. If the user is not authenticated, they are redirected to the login page, with a `returnTo` parameter included to direct them back to their intended screen after successful login.

Additionally, this PR updates the 2 fetch functions to a single `Promise.all` in the guests tab. 