### PR TITLE
Remove `StatusBar` from Expo Router due to styling issues

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "dark",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,7 +5,6 @@ import {
 } from '@expo-google-fonts/poppins';
 import Constants from 'expo-constants';
 import { Stack } from 'expo-router';
-import { StatusBar } from 'expo-status-bar';
 import { Platform, SafeAreaView, StyleSheet, View } from 'react-native';
 import { colors } from '../constants/colors';
 
@@ -35,7 +34,6 @@ export default function HomeLayout() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <StatusBar style="light" />
       <View style={styles.view}>
         <Stack>
           <Stack.Screen


### PR DESCRIPTION
Expo Router currently causes the `StatusBar` component to fail, as reported in [this issue](https://github.com/expo/expo/issues/30497). The router overwrites `StatusBar` properties, preventing styling changes. Expo has addressed this in a PR for a release in [Expo SDK 52](https://github.com/expo/expo/blob/main/packages/expo-router/CHANGELOG.md#400-preview0--2024-10-22).

As a workaround, we're using the `userInterfaceStyle` property in `app.json` to set the status bar text color to `light` or `dark`, which will change the color until SDK 52 is available.